### PR TITLE
Add support to sign at startup

### DIFF
--- a/RemoteSignTool/RemoteSignTool.Client/Program.cs
+++ b/RemoteSignTool/RemoteSignTool.Client/Program.cs
@@ -20,7 +20,7 @@ namespace RemoteSignTool.Client
         private static readonly Dictionary<string, int> supportedSignOptions = new Dictionary<string, int>
         {
             // Certificate selection options
-            { "/a", 1 },
+            { "/a", 0 },
             { "/c", 1 },
             { "/i", 1 },
             { "/n", 1 },

--- a/RemoteSignTool/RemoteSignTool.Server/App.config
+++ b/RemoteSignTool/RemoteSignTool.Server/App.config
@@ -25,6 +25,9 @@
       <setting name="BaseAddress" serializeAs="String">
         <value>http://localhost:9000</value>
       </setting>
+      <setting name="FolderToSignAtStartup" serializeAs="String">
+        <value />
+      </setting>
     </RemoteSignTool.Server.Properties.Settings>
   </userSettings>
 </configuration>

--- a/RemoteSignTool/RemoteSignTool.Server/Design/DesignSignToolService.cs
+++ b/RemoteSignTool/RemoteSignTool.Server/Design/DesignSignToolService.cs
@@ -1,7 +1,6 @@
-﻿using RemoteSignTool.Common.Dto;
+﻿using System.Threading.Tasks;
+using RemoteSignTool.Common.Dto;
 using RemoteSignTool.Server.Services;
-using System;
-using System.Threading.Tasks;
 
 namespace RemoteSignTool.Server.Design
 {

--- a/RemoteSignTool/RemoteSignTool.Server/Design/DesignSignToolService.cs
+++ b/RemoteSignTool/RemoteSignTool.Server/Design/DesignSignToolService.cs
@@ -1,4 +1,7 @@
-﻿using RemoteSignTool.Server.Services;
+﻿using RemoteSignTool.Common.Dto;
+using RemoteSignTool.Server.Services;
+using System;
+using System.Threading.Tasks;
 
 namespace RemoteSignTool.Server.Design
 {
@@ -8,6 +11,16 @@ namespace RemoteSignTool.Server.Design
         {
             path = @"C:\SamplePath\signtool.exe";
             return true;
+        }
+
+        public Task<SignResultDto> Sign(string signToolPath, string signToolArguments, string workingDirectory)
+        {
+            return Task.FromResult(new SignResultDto()
+            {
+                ExitCode = 0,
+                StandardOutput = "",
+                StandardError = ""
+            });
         }
     }
 }

--- a/RemoteSignTool/RemoteSignTool.Server/Properties/Resources.Designer.cs
+++ b/RemoteSignTool/RemoteSignTool.Server/Properties/Resources.Designer.cs
@@ -187,6 +187,15 @@ namespace RemoteSignTool.Server.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The server could not sign files when starting up.
+        /// </summary>
+        public static string SigningAtStartupFailed {
+            get {
+                return ResourceManager.GetString("SigningAtStartupFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to signtool.exe exited with code: {0}.
         /// </summary>
         public static string SignToolExitedWithCodeFormat {

--- a/RemoteSignTool/RemoteSignTool.Server/Properties/Resources.resx
+++ b/RemoteSignTool/RemoteSignTool.Server/Properties/Resources.resx
@@ -164,6 +164,9 @@
   <data name="ServerHasBeenStopped" xml:space="preserve">
     <value>Server has been stopped</value>
   </data>
+  <data name="SigningAtStartupFailed" xml:space="preserve">
+    <value>The server could not sign files when starting up</value>
+  </data>
   <data name="SignToolExitedWithCodeFormat" xml:space="preserve">
     <value>signtool.exe exited with code: {0}</value>
     <comment>{0} - exit code (integer)</comment>

--- a/RemoteSignTool/RemoteSignTool.Server/Properties/Settings.Designer.cs
+++ b/RemoteSignTool/RemoteSignTool.Server/Properties/Settings.Designer.cs
@@ -34,5 +34,17 @@ namespace RemoteSignTool.Server.Properties {
                 this["BaseAddress"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string FolderToSignAtStartup {
+            get {
+                return ((string)(this["FolderToSignAtStartup"]));
+            }
+            set {
+                this["FolderToSignAtStartup"] = value;
+            }
+        }
     }
 }

--- a/RemoteSignTool/RemoteSignTool.Server/Properties/Settings.settings
+++ b/RemoteSignTool/RemoteSignTool.Server/Properties/Settings.settings
@@ -5,5 +5,8 @@
     <Setting Name="BaseAddress" Type="System.String" Scope="User">
       <Value Profile="(Default)">http://localhost:9000</Value>
     </Setting>
+    <Setting Name="FolderToSignAtStartup" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/RemoteSignTool/RemoteSignTool.Server/Services/ISignToolService.cs
+++ b/RemoteSignTool/RemoteSignTool.Server/Services/ISignToolService.cs
@@ -1,9 +1,5 @@
-﻿using RemoteSignTool.Common.Dto;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using RemoteSignTool.Common.Dto;
 
 namespace RemoteSignTool.Server.Services
 {

--- a/RemoteSignTool/RemoteSignTool.Server/Services/ISignToolService.cs
+++ b/RemoteSignTool/RemoteSignTool.Server/Services/ISignToolService.cs
@@ -1,12 +1,16 @@
-﻿using System;
+﻿using RemoteSignTool.Common.Dto;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace RemoteSignTool.Server.Services
 {
     public interface ISignToolService
     {
         bool TryToFindSignToolPath(out string path);
+
+        Task<SignResultDto> Sign(string signToolPath, string signToolArguments, string workingDirectory);            
     }
 }

--- a/RemoteSignTool/RemoteSignTool.Server/Services/SignToolService.cs
+++ b/RemoteSignTool/RemoteSignTool.Server/Services/SignToolService.cs
@@ -1,9 +1,8 @@
-﻿using NLog;
-using RemoteSignTool.Common.Dto;
-using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using NLog;
+using RemoteSignTool.Common.Dto;
 
 namespace RemoteSignTool.Server.Services
 {

--- a/RemoteSignTool/RemoteSignTool.Server/Services/SignToolService.cs
+++ b/RemoteSignTool/RemoteSignTool.Server/Services/SignToolService.cs
@@ -1,4 +1,9 @@
-﻿using System.IO;
+﻿using NLog;
+using RemoteSignTool.Common.Dto;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace RemoteSignTool.Server.Services
 {
@@ -6,6 +11,9 @@ namespace RemoteSignTool.Server.Services
     {
         private const string SignToolX64Path = @"C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe";
         private const string SignToolX86Path = @"C:\Program Files (x86)\Windows Kits\10\bin\x86\signtool.exe";
+        private const string SignTool_15063_X64Path = @"C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x64\signtool.exe";
+
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         public bool TryToFindSignToolPath(out string path)
         {
@@ -19,10 +27,44 @@ namespace RemoteSignTool.Server.Services
                 path = SignToolX86Path;
                 return true;
             }
+            else if (File.Exists(SignTool_15063_X64Path))
+            {
+                path = SignTool_15063_X64Path;
+                return true;
+            }
             else
             {
                 path = null;
                 return false;
+            }
+        }
+
+        public async Task<SignResultDto> Sign(string signToolPath, string signSubcommnands, string workingDirectory)
+        {
+            using (var process = new Process())
+            {
+                var signToolArguments = string.Format("sign {0} *.*", signSubcommnands);
+                Logger.Info(Properties.Resources.ExecutingOnFormat, signToolPath, signToolArguments, workingDirectory);
+
+                process.StartInfo.FileName = signToolPath;
+                process.StartInfo.Arguments = signToolArguments;
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardError = true;
+                process.StartInfo.WorkingDirectory = workingDirectory;
+                process.Start();
+
+                string standardOutput = await process.StandardOutput.ReadToEndAsync();
+                string standardError =  await process.StandardError.ReadToEndAsync();
+
+                process.WaitForExit(300000);
+
+                return new SignResultDto()
+                {
+                    ExitCode = process.ExitCode,
+                    StandardOutput = standardError,
+                    StandardError = standardError
+                };
             }
         }
     }

--- a/RemoteSignTool/RemoteSignTool.Server/ViewModel/MainViewModel.cs
+++ b/RemoteSignTool/RemoteSignTool.Server/ViewModel/MainViewModel.cs
@@ -50,7 +50,7 @@ namespace RemoteSignTool.Server.ViewModel
             if (!_signToolService.TryToFindSignToolPath(out signToolPath))
             {
                 Logger.Error(Properties.Resources.SignToolNotInstalled);
-            }      
+            }
         }
 
         private string _serverStatus = Properties.Resources.Label_ServerIsNotRunning;


### PR DESCRIPTION
When using a EV coding certificate token sometimes the user needs to provide a password for every signing action being done by the token.

However for tokens that are supported by the Safenet Authentication Client the client offers an option to only ask the user for the password once per session.

Idea here is when the server starts to immediately sign a file which will ask the user for the password so the password doesn't have to be entered again when an another client is requesting to sign a file.