### PR TITLE
Add progress loggers for client

### DIFF
--- a/RemoteSignTool/RemoteSignTool.Client/Program.cs
+++ b/RemoteSignTool/RemoteSignTool.Client/Program.cs
@@ -286,12 +286,12 @@ namespace RemoteSignTool.Client
             Logger.Error("Status code: {0}", response.StatusCode);
             Logger.Error(await response.Content.ReadAsStringAsync());
         }
-        private static void SendProgressHandler(object sender, System.Net.Http.Handlers.HttpProgressEventArgs e)
+        private static void SendProgressHandler(object sender, HttpProgressEventArgs e)
         {
             LogProgress("Sending:", e);
         }
 
-        private static void ReceiveProgressHandler(object sender, System.Net.Http.Handlers.HttpProgressEventArgs e)
+        private static void ReceiveProgressHandler(object sender, HttpProgressEventArgs e)
         {
             LogProgress("Receive:", e);
         }

--- a/RemoteSignTool/RemoteSignTool.Client/Program.cs
+++ b/RemoteSignTool/RemoteSignTool.Client/Program.cs
@@ -298,7 +298,7 @@ namespace RemoteSignTool.Client
 
         private static void LogProgress(string prefix, HttpProgressEventArgs e)
         {
-            Logger.Info($"{prefix} ({e.ProgressPercentage}) Transfered: {e.BytesTransferred}, Total: {e.TotalBytes}");
+            Logger.Info($"{prefix} ({e.ProgressPercentage}%) Transfered: {e.BytesTransferred}, Total: {e.TotalBytes}");
         }
     }
 }


### PR DESCRIPTION
when using the client to sign some big files, the console is pretty `quiet` about this.

in order to track the progress on where you're at with the signing, the console will be more than obvious on what the client is doing
<img width="661" alt="screen shot 2017-10-31 at 15 04 28" src="https://user-images.githubusercontent.com/8307102/32225367-9aa78f8e-be4d-11e7-8e2a-368b06e910b3.png">
